### PR TITLE
fix: little refactoring,  better use for `vim.cmd`, docs

### DIFF
--- a/lua/doxygen-previewer/commands.lua
+++ b/lua/doxygen-previewer/commands.lua
@@ -139,3 +139,5 @@ function M.open_temp_doxyfile()
 end
 
 return M
+
+-- vim:ts=2:sts=2:sw=2:et:

--- a/lua/doxygen-previewer/config.lua
+++ b/lua/doxygen-previewer/config.lua
@@ -58,3 +58,5 @@ function M.setup(opts)
 end
 
 return M
+
+-- vim:ts=2:sts=2:sw=2:et:

--- a/lua/doxygen-previewer/doxygen.lua
+++ b/lua/doxygen-previewer/doxygen.lua
@@ -186,3 +186,5 @@ function M.prepare_doxyfile_for_preview(opts, paths, doxygen_opts, user_doxyfile
 end
 
 return M
+
+-- vim:ts=2:sts=2:sw=2:et:

--- a/lua/doxygen-previewer/init.lua
+++ b/lua/doxygen-previewer/init.lua
@@ -9,3 +9,5 @@ M.open = commands.open
 M.update = commands.update
 
 return M
+
+-- vim:ts=2:sts=2:sw=2:et:

--- a/lua/doxygen-previewer/log.lua
+++ b/lua/doxygen-previewer/log.lua
@@ -28,3 +28,5 @@ return setmetatable(M, {
     end
   end,
 })
+
+-- vim:ts=2:sts=2:sw=2:et:

--- a/lua/doxygen-previewer/util.lua
+++ b/lua/doxygen-previewer/util.lua
@@ -96,3 +96,5 @@ function M.find_upward(patterns, start_dir)
 end
 
 return M
+
+-- vim:ts=2:sts=2:sw=2:et:


### PR DESCRIPTION
## Changes

- Added more annotations
- Used `vim.cmd.tabnew()` instead of `vim.cmd('tabnew ...')
- Added Vim comments at EOL to enforce indentation
- Some refactoring