### PR TITLE
fix: added helptags to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Auto-generated Vim Help Tags
+doc/tags


### PR DESCRIPTION
## Description

Sometimes the helptags in `doc/tags` would get in the way of `git` while making my contributions.
This represents a very trivial yet real danger for, say, updating the plugin.